### PR TITLE
修复了一些错误，增加了一些特性

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -44,7 +44,7 @@
   "is_log": {
     "description": "完整日志记录",
     "type": "bool",
-    "default": "false",
+    "default": false,
     "hint": "是否独立保留每一条ccb记录，包括双方与注入量。"
   }
 }

--- a/main.py
+++ b/main.py
@@ -300,14 +300,14 @@ class ccb(Star):
 
                         if crit:
                             chain = [
-                                Comp.Plain(f"你和{nickname}发生了{duration}min长的踩踩背行为，向ta注入了 💥 暴击！{V:.2f}ml的生命因子"),
+                                Comp.Plain(f"你和{nickname}发生了{duration}min长的ccb行为，向ta注入了 💥 暴击！{V:.2f}ml的生命因子"),
                                 Comp.Image.fromURL(pic),
                                 Comp.Plain(f"这是ta的第{item[a2]}次。")
                             ]
                         else:
                             # 发送结果
                             chain = [
-                                Comp.Plain(f"你和{nickname}发生了{duration}min长的踩踩背行为，向ta注入了{V:.2f}ml的生命因子"),
+                                Comp.Plain(f"你和{nickname}发生了{duration}min长的ccb行为，向ta注入了{V:.2f}ml的生命因子"),
                                 Comp.Image.fromURL(pic),
                                 Comp.Plain(f"这是ta的第{item[a2]}次。")
                             ]
@@ -332,7 +332,7 @@ class ccb(Star):
                         return
             except Exception as e:
                 logger.error(f"报错: {e}")
-                yield event.plain_result("对方拒绝了和你踩踩背")
+                yield event.plain_result("对方拒绝了和你ccb")
                 return
 
         else:
@@ -341,7 +341,7 @@ class ccb(Star):
                 nickname = await self._get_nickname(event, target_user_id, strict_event=True)
 
                 chain = [
-                    Comp.Plain(f"你和{nickname}发生了{duration}min长的踩踩背行为，向ta注入了{V:.2f}ml的生命因子"),
+                    Comp.Plain(f"你和{nickname}发生了{duration}min长的ccb行为，向ta注入了{V:.2f}ml的生命因子"),
                     Comp.Image.fromURL(pic),
                     Comp.Plain("这是ta的初体验。")
                 ]
@@ -374,7 +374,7 @@ class ccb(Star):
                 return
             except Exception as e:
                 logger.error(f"报错: {e}")
-                yield event.plain_result("对方拒绝了和你踩踩背")
+                yield event.plain_result("对方拒绝了和你ccb")
                 return
 
     @filter.command("ccbtop")
@@ -385,7 +385,7 @@ class ccb(Star):
         group_id = str(event.get_group_id())
         group_data = self.read_data().get(group_id, [])
         if not group_data:
-            yield event.plain_result("当前群暂无踩踩背记录。")
+            yield event.plain_result("当前群暂无ccb记录。")
             return
 
         top5 = sorted(group_data, key=lambda x: int(x.get(a2, 0)), reverse=True)[:5]
@@ -404,7 +404,7 @@ class ccb(Star):
         group_id = str(event.get_group_id())
         group_data = self.read_data().get(group_id, [])
         if not group_data:
-            yield event.plain_result("当前群暂无踩踩背记录。")
+            yield event.plain_result("当前群暂无ccb记录。")
             return
 
         top5 = sorted(group_data, key=lambda x: float(x.get(a3, 0)), reverse=True)[:5]
@@ -431,7 +431,7 @@ class ccb(Star):
         # 查找目标记录
         record = next((r for r in group_data if r.get(a1) == target_user_id), None)
         if not record:
-            yield event.plain_result("该用户暂无踩踩背记录。")
+            yield event.plain_result("该用户暂无ccb记录。")
             return
 
         # 总次数 & 总注入量
@@ -497,7 +497,7 @@ class ccb(Star):
         group_id = str(event.get_group_id())
         group_data = self.read_data().get(group_id, [])
         if not group_data:
-            yield event.plain_result("当前群暂无踩踩背记录。")
+            yield event.plain_result("当前群暂无ccb记录。")
             return
 
         # 计算max
@@ -563,7 +563,7 @@ class ccb(Star):
         all_data = self.read_data()
         group_data = all_data.get(group_id, [])
         if not group_data:
-            yield event.plain_result("当前群暂无踩踩背记录。")
+            yield event.plain_result("当前群暂无ccb记录。")
             return
 
         # 统计每个人对别人的操作次数
@@ -646,8 +646,8 @@ class ccb(Star):
         self.write_data(all_data)
 
         msg = (
-            f"已清除 {target_user_id} 的 踩踩背 记录：\n"
-            f"删除自身被踩踩背记录：{removed_self} 条\n"
+            f"已清除 {target_user_id} 的 CCB 记录：\n"
+            f"删除自身被CCB记录：{removed_self} 条\n"
             f"移除朝壁他人记录：{removed_from_others} 次\n"
             f"相关记录已重新校准"
         )
@@ -667,8 +667,8 @@ class ccb(Star):
         if target_user_id in self.white_list:
             self.white_list = [uid for uid in self.white_list if uid != target_user_id]
             self._save_white_list()
-            yield event.plain_result(f"已解除 {target_user_id} 的防踩踩背保护")
+            yield event.plain_result(f"已解除 {target_user_id} 的防CCB保护")
         else:
             self.white_list.append(target_user_id)
             self._save_white_list()
-            yield event.plain_result(f"已将 {target_user_id} 加入防踩踩背保护名单")
+            yield event.plain_result(f"已将 {target_user_id} 加入防CCB保护名单")

--- a/main.py
+++ b/main.py
@@ -5,15 +5,18 @@ from astrbot.api import logger
 import astrbot.api.message_components as Comp
 from collections import deque
 from astrbot.api import AstrBotConfig
+from astrbot.core.star import StarTools
 
 import time
 import json
 import random
 import os
 
-DATA_FILE = "data/ccb.json"
+data_dir = StarTools.get_data_dir("astrbot_plugin_ccb_plus")
 
-LOG_FILE = "data/ccb_log.json"
+DATA_FILE = os.path.join(data_dir, "ccb.json")
+
+LOG_FILE = os.path.join(data_dir, "ccb_log.json")
 
 a1 = "id"       # qq号
 a2 = "num"      # 北朝次数

--- a/main.py
+++ b/main.py
@@ -217,7 +217,7 @@ class ccb(Star):
 
         target_user_id = self._get_target_user_id(event)
 
-        if target_user_id in self.white_list:
+        if target_user_id in self.white_list and not await self._is_admin(event):
             nickname = await self._get_nickname(event, target_user_id)
             yield event.plain_result(f"{nickname} 的后门被后户之神霸占了，不能踩踩背（悲")
             return

--- a/main.py
+++ b/main.py
@@ -66,6 +66,19 @@ class ccb(Star):
                 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import AiocqhttpMessageEvent
                 if strict_event:
                     assert isinstance(event, AiocqhttpMessageEvent)
+                # 优先使用群成员信息：群名片(card) > QQ昵称(nickname) > QQ号
+                group_id = event.get_group_id()
+                if group_id:
+                    try:
+                        member_info = await event.bot.api.call_action(
+                            'get_group_member_info', group_id=group_id, user_id=user_id
+                        )
+                        nick = member_info.get("card") or member_info.get("nickname")
+                        if nick:
+                            return nick
+                    except Exception:
+                        pass
+                # 回退：使用陌生人信息
                 stranger_info = await event.bot.api.call_action(
                     'get_stranger_info', user_id=user_id
                 )
@@ -169,7 +182,7 @@ class ccb(Star):
         except Exception as e:
             logger.error(f"append_log 失败: {e}")
 
-    @filter.command("ccb")
+    @filter.command("ccb", alias={'踩踩背', '捶捶背'})
     async def ccb(self, event: AstrMessageEvent):
         """
         ccb，顾名思义，用来ccb
@@ -205,10 +218,7 @@ class ccb(Star):
         target_user_id = self._get_target_user_id(event)
 
         if target_user_id in self.white_list:
-            stranger_info = await event.bot.api.call_action(
-                'get_stranger_info', user_id=target_user_id
-            )
-            nickname = stranger_info.get("nick", target_user_id)
+            nickname = await self._get_nickname(event, target_user_id)
             yield event.plain_result(f"{nickname} 的后门被后户之神霸占了，不能踩踩背（悲")
             return
 

--- a/main.py
+++ b/main.py
@@ -209,7 +209,7 @@ class ccb(Star):
                 'get_stranger_info', user_id=target_user_id
             )
             nickname = stranger_info.get("nick", target_user_id)
-            yield event.plain_result(f"{nickname} 的后门被后户之神霸占了，不能ccb（悲")
+            yield event.plain_result(f"{nickname} 的后门被后户之神霸占了，不能踩踩背（悲")
             return
 
         if target_user_id == actor_id and not self.selfdo:
@@ -287,14 +287,14 @@ class ccb(Star):
 
                         if crit:
                             chain = [
-                                Comp.Plain(f"你和{nickname}发生了{duration}min长的ccb行为，向ta注入了 💥 暴击！{V:.2f}ml的生命因子"),
+                                Comp.Plain(f"你和{nickname}发生了{duration}min长的踩踩背行为，向ta注入了 💥 暴击！{V:.2f}ml的生命因子"),
                                 Comp.Image.fromURL(pic),
                                 Comp.Plain(f"这是ta的第{item[a2]}次。")
                             ]
                         else:
                             # 发送结果
                             chain = [
-                                Comp.Plain(f"你和{nickname}发生了{duration}min长的ccb行为，向ta注入了{V:.2f}ml的生命因子"),
+                                Comp.Plain(f"你和{nickname}发生了{duration}min长的踩踩背行为，向ta注入了{V:.2f}ml的生命因子"),
                                 Comp.Image.fromURL(pic),
                                 Comp.Plain(f"这是ta的第{item[a2]}次。")
                             ]
@@ -319,7 +319,7 @@ class ccb(Star):
                         return
             except Exception as e:
                 logger.error(f"报错: {e}")
-                yield event.plain_result("对方拒绝了和你ccb")
+                yield event.plain_result("对方拒绝了和你踩踩背")
                 return
 
         else:
@@ -328,7 +328,7 @@ class ccb(Star):
                 nickname = await self._get_nickname(event, target_user_id, strict_event=True)
 
                 chain = [
-                    Comp.Plain(f"你和{nickname}发生了{duration}min长的ccb行为，向ta注入了{V:.2f}ml的生命因子"),
+                    Comp.Plain(f"你和{nickname}发生了{duration}min长的踩踩背行为，向ta注入了{V:.2f}ml的生命因子"),
                     Comp.Image.fromURL(pic),
                     Comp.Plain("这是ta的初体验。")
                 ]
@@ -361,7 +361,7 @@ class ccb(Star):
                 return
             except Exception as e:
                 logger.error(f"报错: {e}")
-                yield event.plain_result("对方拒绝了和你ccb")
+                yield event.plain_result("对方拒绝了和你踩踩背")
                 return
 
     @filter.command("ccbtop")
@@ -372,7 +372,7 @@ class ccb(Star):
         group_id = str(event.get_group_id())
         group_data = self.read_data().get(group_id, [])
         if not group_data:
-            yield event.plain_result("当前群暂无ccb记录。")
+            yield event.plain_result("当前群暂无踩踩背记录。")
             return
 
         top5 = sorted(group_data, key=lambda x: int(x.get(a2, 0)), reverse=True)[:5]
@@ -391,7 +391,7 @@ class ccb(Star):
         group_id = str(event.get_group_id())
         group_data = self.read_data().get(group_id, [])
         if not group_data:
-            yield event.plain_result("当前群暂无ccb记录。")
+            yield event.plain_result("当前群暂无踩踩背记录。")
             return
 
         top5 = sorted(group_data, key=lambda x: float(x.get(a3, 0)), reverse=True)[:5]
@@ -418,7 +418,7 @@ class ccb(Star):
         # 查找目标记录
         record = next((r for r in group_data if r.get(a1) == target_user_id), None)
         if not record:
-            yield event.plain_result("该用户暂无ccb记录。")
+            yield event.plain_result("该用户暂无踩踩背记录。")
             return
 
         # 总次数 & 总注入量
@@ -484,7 +484,7 @@ class ccb(Star):
         group_id = str(event.get_group_id())
         group_data = self.read_data().get(group_id, [])
         if not group_data:
-            yield event.plain_result("当前群暂无ccb记录。")
+            yield event.plain_result("当前群暂无踩踩背记录。")
             return
 
         # 计算max
@@ -550,7 +550,7 @@ class ccb(Star):
         all_data = self.read_data()
         group_data = all_data.get(group_id, [])
         if not group_data:
-            yield event.plain_result("当前群暂无ccb记录。")
+            yield event.plain_result("当前群暂无踩踩背记录。")
             return
 
         # 统计每个人对别人的操作次数
@@ -633,8 +633,8 @@ class ccb(Star):
         self.write_data(all_data)
 
         msg = (
-            f"已清除 {target_user_id} 的 CCB 记录：\n"
-            f"删除自身被CCB记录：{removed_self} 条\n"
+            f"已清除 {target_user_id} 的 踩踩背 记录：\n"
+            f"删除自身被踩踩背记录：{removed_self} 条\n"
             f"移除朝壁他人记录：{removed_from_others} 次\n"
             f"相关记录已重新校准"
         )
@@ -654,8 +654,8 @@ class ccb(Star):
         if target_user_id in self.white_list:
             self.white_list = [uid for uid in self.white_list if uid != target_user_id]
             self._save_white_list()
-            yield event.plain_result(f"已解除 {target_user_id} 的防CCB保护")
+            yield event.plain_result(f"已解除 {target_user_id} 的防踩踩背保护")
         else:
             self.white_list.append(target_user_id)
             self._save_white_list()
-            yield event.plain_result(f"已将 {target_user_id} 加入防CCB保护名单")
+            yield event.plain_result(f"已将 {target_user_id} 加入防踩踩背保护名单")

--- a/main.py
+++ b/main.py
@@ -11,12 +11,27 @@ import time
 import json
 import random
 import os
+import shutil
 
 data_dir = StarTools.get_data_dir("astrbot_plugin_ccb_plus")
 
 DATA_FILE = os.path.join(data_dir, "ccb.json")
 
 LOG_FILE = os.path.join(data_dir, "ccb_log.json")
+
+#migration
+old_data_file = "data/ccb.json"
+old_log_file = "data/ccb_log.json"
+
+try:
+    os.makedirs(data_dir, exist_ok=True)
+    # 复制数据文件
+    if os.path.exists(old_data_file) and not os.path.exists(DATA_FILE):
+        shutil.copy2(old_data_file, DATA_FILE)
+    if os.path.exists(old_log_file) and not os.path.exists(LOG_FILE):
+            shutil.copy2(old_log_file, LOG_FILE)
+except Exception:
+    pass
 
 a1 = "id"       # qq号
 a2 = "num"      # 北朝次数


### PR DESCRIPTION
该设置项的默认类型错误，定义为bool，但实际为str
导致用户如果没有修改过该设置项的默认值将无法通过GUI修改配置

修复了消息中昵称错误显示为uid的问题，现在会尝试获取用户的昵称显示

为ccb指令添加了别名

现在管理员可以绕过后户之神了

修复了插件将数据存放在核心数据根目录的错误，现在插件会将数据存放在插件对应的数据目录中